### PR TITLE
Add default value for optional type

### DIFF
--- a/src/aido_schemas/protocol_simulator.py
+++ b/src/aido_schemas/protocol_simulator.py
@@ -172,7 +172,7 @@ class ScenarioRobotSpec:
     configuration: RobotConfiguration
 
     # if not playable
-    motion: Optional[NPMotion]
+    motion: Optional[NPMotion] = None
 
 
 @dataclass
@@ -180,7 +180,7 @@ class SpawnRobot:
     playable: bool
     robot_name: RobotName
     configuration: RobotConfiguration
-    motion: Optional[NPMotion]
+    motion: Optional[NPMotion] = None
 
 
 @dataclass


### PR DESCRIPTION
Right now we are getting error from the FIFOs if the client/server are not using the same version of aido-protocols, since there are new (optional) field. It seems like zuper-utils is not robust to optional types, and we get the following error if there are new optional fields:

https://pastebin.com/cgkP4dCw

I think that by adding a default value to the dataclass we would be able to handle backward compatibility for communication with other version of the schemas, and serializing the new class would use the default value.